### PR TITLE
Handle the replacement of -dev package if new -cli is present

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -52,8 +52,10 @@ Architecture: any
 Depends: libgz-plugin2 (= ${binary:Version}),
          ${shlibs:Depends},
          ${misc:Depends}
-Breaks: ignition-plugin2-cli (<< 1.999.999+nightly+git20220630+1r3262c92257b72c3c82d788ae5aa1d54c464261e4-1)
-Replaces: ignition-plugin2-cli (<< 1.999.999+nightly+git20220630+1r3262c92257b72c3c82d788ae5aa1d54c464261e4-1)
+Breaks: ignition-plugin2-cli (<< 1.999.999+nightly+git20220630+1r3262c92257b72c3c82d788ae5aa1d54c464261e4-1),
+        libgz-plugin2-dev (<< 2.0.2-1)
+Replaces: ignition-plugin2-cli (<< 1.999.999+nightly+git20220630+1r3262c92257b72c3c82d788ae5aa1d54c464261e4-1),
+          libgz-plugin2-dev (<< 2.0.2-1)
 Multi-Arch: no
 Description: Collection of useful code used by robotics apps - CLI tool
  Gazebo Plugin is a component in the Gazebo framework, a set of libraries

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -53,9 +53,9 @@ Depends: libgz-plugin2 (= ${binary:Version}),
          ${shlibs:Depends},
          ${misc:Depends}
 Breaks: ignition-plugin2-cli (<< 1.999.999+nightly+git20220630+1r3262c92257b72c3c82d788ae5aa1d54c464261e4-1),
-        libgz-plugin2-dev (<< 2.0.2-1)
+        libgz-plugin2-dev (<< 2.0.1+)
 Replaces: ignition-plugin2-cli (<< 1.999.999+nightly+git20220630+1r3262c92257b72c3c82d788ae5aa1d54c464261e4-1),
-          libgz-plugin2-dev (<< 2.0.2-1)
+          libgz-plugin2-dev (<< 2.0.1+)
 Multi-Arch: no
 Description: Collection of useful code used by robotics apps - CLI tool
  Gazebo Plugin is a component in the Gazebo framework, a set of libraries


### PR DESCRIPTION
Fix #15

The situation of having new packages that ships files that were previously shipped by other packages is a common use described in the Debian documentation: [overwriting file in other packages ](https://www.debian.org/doc/debian-policy/ch-relationships.html#overwriting-files-in-other-packages) and particularly in ["Split: only A existed; move some files from A to B; new A does not require new B".](https://wiki.debian.org/PackageTransition)

Given that our last stable version is `2.0.1-1`, I'm ussing `2.0.2-1` as the reference, should cover all nightlies until we release `2.0.2`.